### PR TITLE
Bump @itk-wasm/cuberille to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "niivue-brainchop",
       "version": "0.1.0",
       "dependencies": {
-        "@itk-wasm/cuberille": "^0.1.0",
+        "@itk-wasm/cuberille": "^0.2.0",
         "@itk-wasm/mesh-filters": "^0.1.0",
         "@niivue/cbor-loader": "^1.1.0",
         "@niivue/niivue": "^0.44.2",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@itk-wasm/cuberille": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@itk-wasm/cuberille/-/cuberille-0.1.0.tgz",
-      "integrity": "sha512-ftbGcnMkEBmIDO2s95AJFXEL9DwnR0XtaH0I0+mAdHo/JggNw5/gKbViGod7TDwm+9Y+ZRXqBaCjGc6372bgWw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@itk-wasm/cuberille/-/cuberille-0.2.0.tgz",
+      "integrity": "sha512-8yXqAiIchswnMvILxOXM67p+H6zAUil/Rd5SFitjCD7XnMR9edpTNzQ/BEsLiaTlyVxGPnjv3QX4px43ZlRegA==",
       "dependencies": {
         "itk-wasm": "1.0.0-b.184"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@itk-wasm/cuberille": "^0.1.0",
+    "@itk-wasm/cuberille": "^0.2.0",
     "@itk-wasm/mesh-filters": "^0.1.0",
     "@niivue/cbor-loader": "^1.1.0",
     "@niivue/niivue": "^0.44.2",


### PR DESCRIPTION
This brings in a fix so the `noClosing` option is honored, which
improves the result.
