### PR TITLE
bump niimath version and enable some safari on tablet and desktop

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,40 @@ const pipelinesBaseUrl = new URL(`${viteBaseUrl}pipelines`, document.location.or
 setCuberillePipelinesUrl(pipelinesBaseUrl)
 setMeshFiltersPipelinesUrl(pipelinesBaseUrl)
 
+function isDesktopModeiPad() {
+  const ua = navigator.userAgent;
+  return (
+    ua.includes("Macintosh") &&
+    navigator.maxTouchPoints &&
+    navigator.maxTouchPoints > 1
+  );
+}
+
+function getAppleDeviceType() {
+  const ua = navigator.userAgent;
+  console.log(ua)
+
+  // test for desktop based safari
+  if (ua.includes("Macintosh")) {
+    return true
+  }
+
+  if (/iPad/.test(ua)) {
+    return true
+  }
+
+  if (isDesktopModeiPad()) {
+    return true
+  }
+
+  if (/iPhone/.test(ua)) {
+    alert("brain2print is not supported on some mobile devices yet. Please use a desktop browser or tablet.")
+    return false
+  }
+
+  return false
+}
+
 async function main() {
   const niimath = new Niimath()
   await niimath.init()
@@ -304,7 +338,19 @@ async function main() {
   }
   nv1.onImageLoaded = doLoadImage
   modelSelect.selectedIndex = -1
-  workerCheck.checked = await isChrome(); //TODO: Safari does not yet support WebGL TFJS webworkers, test FireFox
+  // workerCheck.checked = await isChrome(); TODO: test firefox
+  // modern iPadOS Safari requests the site as if it were a desktop browser by default,
+  // and these devices are more capable than iPhones so we should allow them. 
+  // Desktop Safari is also supported.
+  workerCheck.checked = getAppleDeviceType()
+  // now check for isChrome
+  workerCheck.checked = !workerCheck.checked ? await isChrome() : workerCheck.checked
+  // if the worker is not checked, then no segmentation will be performed. 
+  // Previously this was a silent failure, but it is probably better to alert the user.
+  if (!workerCheck.checked) {
+    alert("brain2print may not be able to reliably run segmentation in your browser. Segmentation will not be performed.")
+  }
+
   console.log('brain2print 20241218')
   // uncomment next two lines to automatically run segmentation when web page is loaded
   //   modelSelect.selectedIndex = 11

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@itk-wasm/cuberille": "^0.2.0",
         "@itk-wasm/mesh-filters": "^0.2.0",
         "@niivue/cbor-loader": "^1.1.0",
-        "@niivue/niimath": "^0.3.0",
+        "@niivue/niimath": "^1.0.0",
         "@niivue/niivue": "^0.44.2",
         "@tensorflow/tfjs": "^4.19.0",
         "gl-matrix": "^3.4.3"
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@niivue/niimath": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@niivue/niimath/-/niimath-0.3.0.tgz",
-      "integrity": "sha512-6JRPJZLm8DU7MItTsFs0FCJ/48m6K053PMSwmiqTE56snWhNjlR2SEUxxLnvsqjiRtAfiQVJL8aCsmHsEWsDMQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@niivue/niimath/-/niimath-1.0.0.tgz",
+      "integrity": "sha512-idLiiGHoBfWuWdLppepyr/nlY5/6CRp1EsYB7Hb6058GdQ/gOOcONWkW7XFWT0TzhFEMzyTAMBG09Pkv3c852A==",
       "license": "BSD-2-Clause"
     },
     "node_modules/@niivue/niivue": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@niivue/niimath": "^0.3.0",
+    "@niivue/niimath": "^1.0.0",
     "@itk-wasm/cuberille": "^0.2.0",
     "@itk-wasm/mesh-filters": "^0.2.0",
     "@niivue/cbor-loader": "^1.1.0",


### PR DESCRIPTION
This PR bumps niimath to the latest version and enables Safari as an allowed browser if running on desktop or iPadOS. 

I have tested this on macOS 15.2, iPadOS 18.2, and iOS 18.2. The iOS device is correctly not allowed to run the models, but desktop and iPads are. Tested on macOS laptop with M3 Max, and iPad Pro with M4 chip. Admittedly, these devices are all "pro-level" and I have not tested with lower end mobile devices from the Apple ecosystem. 

I did try to run the models on my iPhone 15 pro max and even the lightweight three class segmentation model fails. So These devices should be disallowed. 

Users are now alerted if their device is likely to not work. Previously, this was a silent check and we never actually told users that their device probably won't work. 