### PR TITLE
fix(meshing): create surface from all labels with quality extraction

### DIFF
--- a/main.js
+++ b/main.js
@@ -331,6 +331,12 @@ async function main() {
     if (nv1.volumes[nv1.volumes.length - 1].hdr.intent_code === 0) {
       ({ mesh } = await cuberille(itkImage, { isoSurfaceValue: 240 }))
     } else {
+      // Binarize the image: set all values >= 1 to 1
+      for (let i = 0; i < itkImage.data.length; i++) {
+        if (itkImage.data[i] >= 1) {
+          itkImage.data[i] = 1;
+        }
+      }
       ({ mesh } = await antiAliasCuberille(itkImage, { noClosing: true }))
     }
 


### PR DESCRIPTION
Generate a single STL mesh output from all labels when segmented with a
method like `Subcortical + GWM (Failsafe, Less Acc)`. Matches the
behavior of the faster mesh extraction. Closes #13.
